### PR TITLE
Fix #3: Add plugin descriptor to main sourceset.

### DIFF
--- a/src/main/groovy/nu/studer/gradle/plugindev/GeneratePluginDescriptorTask.groovy
+++ b/src/main/groovy/nu/studer/gradle/plugindev/GeneratePluginDescriptorTask.groovy
@@ -44,7 +44,7 @@ class GeneratePluginDescriptorTask extends DefaultTask {
     @OutputFile
     public File getPropertiesFile() {
         def resolvedPluginId = Closures.resolveAsString(pluginId)
-        project.file("${project.buildDir}/plugindev/${resolvedPluginId}.properties")
+        project.file("${project.buildDir}/plugindev/META-INF/gradle-plugins/${resolvedPluginId}.properties")
     }
 
     @TaskAction

--- a/src/main/groovy/nu/studer/gradle/plugindev/PluginDevPlugin.groovy
+++ b/src/main/groovy/nu/studer/gradle/plugindev/PluginDevPlugin.groovy
@@ -126,11 +126,11 @@ class PluginDevPlugin implements Plugin<Project> {
         generatePluginDescriptorFile.pluginVersion = { project.version }
         LOGGER.debug("Registered task '$generatePluginDescriptorFile.name'")
 
-        // include the plugin descriptor in the production jar file
-        Jar jarTask = project.tasks[JavaPlugin.JAR_TASK_NAME] as Jar
-        jarTask.into(PLUGIN_DESCRIPTOR_LOCATION) { from generatePluginDescriptorFile }
+        // include the plugin descriptor in the main source set
+        mainSourceSet.output.dir("${project.buildDir}/plugindev", builtBy: generatePluginDescriptorFileTaskName)
 
         // ensure the production jar file contains the declared plugin implementation class
+        Jar jarTask = project.tasks[JavaPlugin.JAR_TASK_NAME] as Jar
         def findImplementationClass = new ClassFileMatchingAction({ pluginDevExtension.pluginImplementationClass })
         jarTask.filesMatching("**/*.class", findImplementationClass)
         jarTask.doLast({


### PR DESCRIPTION
- Adding to the main sourceset instead of directly to the jar file
  makes the plugin descriptor available in the test classpath so the
  plugin may be applied in tests, etc.

This seemed like the best way to accomplish this, but let me know if there is a better way.
