### PR TITLE
Update to be compatible with gradle 2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,4 +40,4 @@ bintray {
     dryRun = false
 }
 
-wrapper.gradleVersion = '1.12'
+wrapper.gradleVersion = '2.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # plugin dependency versions
 plugindevPluginVersion = 1.0.3
-credentialsPluginVersion = 1.0.0
+credentialsPluginVersion = 1.0.1
 
 # compile/runtime dependency versions
-bintrayPluginVersion = 0.6
+bintrayPluginVersion = 1.2
 orderedPropertiesVersion = 1.0.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 29 16:56:47 CEST 2014
+#Tue May 05 21:27:17 EDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip


### PR DESCRIPTION

The code as is will use gradle 2.3 to publish plugindev to bintray.

The published plugin can be used with gradle 2.4

