### PR TITLE
Bump Gradle Wrapper from 7.6-20221024231219+0000 to 7.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.6-20221024231219+0000-bin.zip
+distributionSha256Sum=7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bumps Gradle Wrapper from 7.6-20221024231219+0000 to 7.6.

Release notes of Gradle 7.6 can be found here:
https://docs.gradle.org/7.6/release-notes.html